### PR TITLE
update action version

### DIFF
--- a/.github/workflows/keeper-deploy.yaml
+++ b/.github/workflows/keeper-deploy.yaml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.KEEPER_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.KEEPER_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
We'll need to update the GitHub actions that rely on node12 since it's deprecated now. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

cc @eskp @sanbotto @OleksandrUA @cristidas @jeannettemcd @zdumitru